### PR TITLE
Configurable postgres host

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -14,7 +14,7 @@ ENV_VARS = ['POSTGRES_DB', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD'
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD']
+                     'REDIS_PASSWORD', 'POSTGRES_HOST']
 
 for loc in ENV_VARS + OPTIONAL_ENV_VARS:
     locals()[loc] = os.environ.get(loc)
@@ -46,7 +46,7 @@ DATABASES = {
         'NAME': POSTGRES_DB,
         'USER': POSTGRES_USER,
         'PASSWORD': POSTGRES_PASSWORD,
-        'HOST': "db-postgres",
+        'HOST': (POSTGRES_HOST if 'POSTGRES_HOST' in os.environ else "db-postgres"),
         'PORT': POSTGRES_PORT,
     }
 }

--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict -t 0 db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict -t 0 db-redis:6379

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict db-redis:6379


### PR DESCRIPTION
#### Any background context you want to provide?
The SEED Docker image currently assumes its PostgreSQL database
will be on a host with a well-known, hard-coded name.
We (OPEN) want to use the Docker image in the situation
where the database is on a host with a different name.
#### What's this PR do?
This changes the Docker image and startup script
so that they allow configuring the PostgreSQL host,
but default to the hard-coded value, for backwards compatibility.
#### How should this be manually tested?
Build and run the Docker image locally, setting
the `POSTGRES_HOST` environment variable
to a valid host name. Ensure the application starts up
and that you can log in to the Web interface. Check
the logs to ensure the database migrations have run.
