### PR TITLE
Allow SMTP email backend for Docker image

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -14,7 +14,9 @@ ENV_VARS = ['POSTGRES_DB', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD'
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD', 'POSTGRES_HOST', 'DJANGO_EMAIL_BACKEND']
+                     'REDIS_PASSWORD', 'POSTGRES_HOST', 'DJANGO_EMAIL_BACKEND',
+                     'EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_HOST_USER',
+                     'EMAIL_HOST_PASSWORD', 'EMAIL_USE_TLS', 'EMAIL_USE_SSL']
 
 for loc in ENV_VARS + OPTIONAL_ENV_VARS:
     locals()[loc] = os.environ.get(loc)

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -14,7 +14,7 @@ ENV_VARS = ['POSTGRES_DB', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD'
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD', 'POSTGRES_HOST']
+                     'REDIS_PASSWORD', 'POSTGRES_HOST', 'DJANGO_EMAIL_BACKEND']
 
 for loc in ENV_VARS + OPTIONAL_ENV_VARS:
     locals()[loc] = os.environ.get(loc)
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = ['*']
 # By default we are using SES as our email client. If you would like to use
 # another backend (e.g. SMTP), then please update this model to support both and
 # create a pull request.
-EMAIL_BACKEND = 'django_ses.SESBackend'
+EMAIL_BACKEND = (DJANGO_EMAIL_BACKEND if 'DJANGO_EMAIL_BACKEND' in os.environ else "django_ses.SESBackend")
 
 # PostgreSQL DB config
 DATABASES = {


### PR DESCRIPTION
#### Any background context you want to provide?
The Docker image currently only supports the AWS SES
email backend. We (OPEN) would like the flexibility to use
SMTP for sending email.
#### What's this PR do?
This PR changes the Docker config file so that
it allows configuring different values for the email backend
that Django will use. It also copies the values from
Django's SMTP-related environment variables into memory.
#### How should this be manually tested?
1. Build a new version of the Docker image.
2. Customize the docker-compose config file
    to include values for the following environment variables:
  - DJANGO_EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
  - SERVER_EMAIL=???
  - EMAIL_HOST=???
  - EMAIL_PORT=???
  - EMAIL_USE_TLS=True _or_ EMAIL_USE_SSL=True
  - EMAIL_HOST_USER=???
  - EMAIL_HOST_PASSWORD=???
3. Run the Docker image using docker-compose.
4. Log in to the Web application.
5. Create or invite a new user with a real email address to join an organization
    in SEED.
6.  Verify that the user receives an email about their new account.
