### PR TITLE
Remove some more customizations

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -221,6 +221,7 @@ LOG_FILE = os.path.join(BASE_DIR, '../logs/py.log/')
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 SERVER_EMAIL = 'info@seed-platform.org'
 PASSWORD_RESET_EMAIL = SERVER_EMAIL
+DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 # Added By Gavin on 1/27/2014
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -41,6 +41,7 @@ ALLOWED_HOSTS = ['*']
 # another backend (e.g. SMTP), then please update this model to support both and
 # create a pull request.
 EMAIL_BACKEND = (DJANGO_EMAIL_BACKEND if 'DJANGO_EMAIL_BACKEND' in os.environ else "django_ses.SESBackend")
+DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
 # PostgreSQL DB config
 DATABASES = {

--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -14,7 +14,7 @@ ENV_VARS = ['POSTGRES_DB', 'POSTGRES_PORT', 'POSTGRES_USER', 'POSTGRES_PASSWORD'
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD', 'POSTGRES_HOST', 'DJANGO_EMAIL_BACKEND',
+                     'REDIS_PASSWORD', 'DJANGO_EMAIL_BACKEND',
                      'EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_HOST_USER',
                      'EMAIL_HOST_PASSWORD', 'EMAIL_USE_TLS', 'EMAIL_USE_SSL',
                      'PASSWORD_RESET_EMAIL']
@@ -49,7 +49,7 @@ DATABASES = {
         'NAME': POSTGRES_DB,
         'USER': POSTGRES_USER,
         'PASSWORD': POSTGRES_PASSWORD,
-        'HOST': (POSTGRES_HOST if 'POSTGRES_HOST' in os.environ else "db-postgres"),
+        'HOST': "db-postgres",
         'PORT': POSTGRES_PORT,
     }
 }


### PR DESCRIPTION
#### Any background context you want to provide?
#### What's this PR do?
Removes a couple of customizations that are no longer needed by OPEN Technologies.
- Removes support for setting PostgreSQL host name via an environment variable,
  only used in the Docker configuration.
- Adds back the DEFAULT_FROM_EMAIL config var, which wasn't being used,
  but didn't urgently need to be removed, either.

#### How should this be manually tested?
This shouldn't have any effect on functionality. All manual and automated tests should pass. 
#### What are the relevant tickets?
#### Screenshots (if appropriate)
