### PR TITLE
Revert customizations to Docker startup scripts

### DIFF
--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -3,13 +3,7 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-if [ -v POSTGRES_HOST ];
-then
-   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
-else
-   POSTGRES_ACTUAL_HOST=db-postgres
-fi
-/usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
+/usr/local/wait-for-it.sh --strict -t 0 db-postgres:5432
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict -t 0 db-redis:6379

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -3,13 +3,7 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-if [ -v POSTGRES_HOST ];
-then
-   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
-else
-   POSTGRES_ACTUAL_HOST=db-postgres
-fi
-/usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
+/usr/local/wait-for-it.sh --strict db-postgres:5432
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict db-redis:6379


### PR DESCRIPTION
#### Any background context you want to provide?
We (OPEN) customized two startup scripts for the SEED Docker image
so that they'd be able to look for PostgreSQL in a location outside of
Docker. We no longer need those customizations.

#### What's this PR do?
This PR reverts the two scripts so they match their upstream versions.

