### PR TITLE
Restore PostgreSQL host customization in Docker config

### DIFF
--- a/config/settings/docker.py
+++ b/config/settings/docker.py
@@ -19,7 +19,8 @@ SMTP_ENV_VARS = ['EMAIL_HOST', 'EMAIL_PORT', 'EMAIL_HOST_USER',
 # The optional vars will set the SERVER_EMAIL information as needed
 OPTIONAL_ENV_VARS = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SES_REGION_NAME',
                      'AWS_SES_REGION_ENDPOINT', 'SERVER_EMAIL', 'SENTRY_JS_DSN', 'SENTRY_RAVEN_DSN',
-                     'REDIS_PASSWORD', 'DJANGO_EMAIL_BACKEND', 'PASSWORD_RESET_EMAIL'] + SMTP_ENV_VARS
+                     'REDIS_PASSWORD', 'DJANGO_EMAIL_BACKEND',
+                     'PASSWORD_RESET_EMAIL', 'POSTGRES_HOST'] + SMTP_ENV_VARS
 
 for loc in ENV_VARS + OPTIONAL_ENV_VARS:
     locals()[loc] = os.environ.get(loc)
@@ -52,7 +53,7 @@ DATABASES = {
         'NAME': POSTGRES_DB,
         'USER': POSTGRES_USER,
         'PASSWORD': POSTGRES_PASSWORD,
-        'HOST': "db-postgres",
+        'HOST': (POSTGRES_HOST if 'POSTGRES_HOST' in os.environ else "db-postgres"),
         'PORT': POSTGRES_PORT,
     }
 }

--- a/docker/start_celery_docker.sh
+++ b/docker/start_celery_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict -t 0 db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict -t 0 $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict -t 0 db-redis:6379

--- a/docker/start_uwsgi_docker.sh
+++ b/docker/start_uwsgi_docker.sh
@@ -3,7 +3,13 @@
 cd /seed
 
 echo "Waiting for postgres to start"
-/usr/local/wait-for-it.sh --strict db-postgres:5432
+if [ -v POSTGRES_HOST ];
+then
+   POSTGRES_ACTUAL_HOST=$POSTGRES_HOST
+else
+   POSTGRES_ACTUAL_HOST=db-postgres
+fi
+/usr/local/wait-for-it.sh --strict $POSTGRES_ACTUAL_HOST:$POSTGRES_PORT
 
 echo "Waiting for redis to start"
 /usr/local/wait-for-it.sh --strict db-redis:6379


### PR DESCRIPTION
#### Any background context you want to provide?
- we (OPEN) have an external PostgreSQL server, not under Docker's control,
  that we connect our Dockerized SEED instance to in production
- i tried removing some customizations that allow us to point
  our SEED instance to the PostgreSQL server, and instead depend upon
  Docker's own configuration to create the mapping between the two services
- turns out that's much harder than just keeping the customizations we made
#### What's this PR do?
- it restores support for the custom POSTGRESQL_HOST environment variable,
  used in the Docker configuration for SEED,
  that lets you point to a PostgreSQL server not under Docker's control
#### How should this be manually tested?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
