### PR TITLE
GRID-4410: fix en-US l10n

### DIFF
--- a/seed/static/seed/locales/en_US.json
+++ b/seed/static/seed/locales/en_US.json
@@ -56,12 +56,7 @@
     "Analysis Name": "Analysis Name",
     "Analysis Name (User Defined)": "Analysis Name (User Defined)",
     "Analysis State": "Analysis State",
-    "and": "and",
-    "AND": "AND",
     "and our Privacy Policy is available here": "and our Privacy Policy is available here",
-    "API Documentation": "API Documentation",
-    "API Key": "API Key",
-    "api key": "api key",
     "Apply Profile": "Apply Profile",
     "Are you absolutely sure you want to delete the organization": "Are you absolutely sure you want to delete the organization",
     "Are you absolutely sure you want to delete the sub-organization": "Are you absolutely sure you want to delete the sub-organization",
@@ -1022,4 +1017,3 @@
     "white": "white",
     "your data set name": "your data set name"
 }
-,


### PR DESCRIPTION
#### Any background context you want to provide?
- there was a trailing comma and a few duplicated keys in the en-US
  localization. these might have been introduced while we (OPEN) were resolving
  merge conflicts.
- these issues with the file seem to have been causing weird placeholder text
  to appear all over the SEED user interface.

#### What's this PR do?
- it removes the trailing comma and the duplicated keys in the file.

#### How should this be manually tested?
1. Log in to SEED.
2. You should be directed to the home page.
3. On the home page, you should see three sections of text, side-by-side. 
4. You shouldn't see placeholder text, like MARKETING_BULLETIN_1, in those three sections.
5. Go to the Inventory tab.
6. On the right-hand side of the page, you should see the number of properties in the list.
7. You should not see placeholder text, like NUM_PROPERTIES.

#### What are the relevant tickets?
- see [GRID-4410](https://opentech-cast.monday.com/boards/1256768982/pulses/2824144410)

#### Screenshots (if appropriate)
N/A
