### PR TITLE
:bug: fix error when viewing the About page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,10 @@ WORKDIR /seed
 COPY . /seed/
 COPY ./docker/wait-for-it.sh /usr/local/wait-for-it.sh
 
+# OPENGB: fix a permission error when attempting to view the About page (it
+# calls `git rev-parse` on the `/seed` directory).
+RUN git config --system --replace-all safe.directory /seed
+
 # nginx configuration - replace the root/default nginx config file
 COPY /docker/nginx-seed.conf /etc/nginx/nginx.conf
 # symlink maintenance.html that nginx will serve in the case of a 503


### PR DESCRIPTION
#### Any background context you want to provide?
- the About page invokes a shell command, `git rev-parse`,
  in order to display the current version of SEED to the user.
- in OPEN's forked version of SEED, when running the application
  in Docker, this shell command fails with an error.
  git states that SEED's directory (`/seed`) is owned by a different user
  and suggests running `git config --global --add safe.directory /seed`
  to fix the problem.
- for some reason the official SEED Docker images don't have this problem.
  i don't yet know how they are able to avoid running the above `git config`
  command as part of the Docker recipe.
- we should ask the official SEED maintainers how they were able to avoid
  including this step in their Docker file.

#### What's this PR do?
- to solve this bug for now, alter the Docker recipe to include
  a step for running `git config`.

#### How should this be manually tested?
The following steps assume you will be testing on your own development machine.
1. Run the SEED Docker image.
3. Navigate to http://localhost:9000/ .
4. Log in to SEED. Look at the values of the SEED_ADMIN_USER and SEED_ADMIN_PASSWORD environment variables to find out what credentials to use. They're likely defined in the Docker Compose config file you used to start up SEED.
5. Navigate to the About page. The button is in the sidebar on the left-hand side of the page after you've logged in.
6. You should see the About page.

#### What are the relevant tickets?
- see [GRID-9991](https://opentech-cast.monday.com/boards/1256768982/pulses/2808109991)

#### Screenshots (if appropriate)
N/A
