### PR TITLE
FLEX-150: :bug: Fix database connection error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM alpine:3.14
 
+ENV PGSSLCERT /tmp/postgresql.crt
+
 RUN apk add --no-cache python3-dev \
         postgresql-dev \
         coreutils \


### PR DESCRIPTION
#### Any background context you want to provide?
- Our last attempt to upgrade SEED didn't work. See the FLEX ticket (and linked Slack thread) for more background info. In short, the upgraded version of SEED couldn't connect to our PostgreSQL server on DigitalOcean.

#### What's this PR do?
- This PR is an attempt to fix that problem so we can safely upgrade.
- It involves setting one of the PostgreSQL client's environment variables to a safe but meaningless value. This avoids the error we were seeing after the previous attempt at upgrading.

#### How should this be manually tested?
1. Edit the `systems/seed-docker/docker-compose.yml` file to use `opengb/seed:opengb-develop-v2.19.0-flex-150`, in your local copy of the GRID GitHub repository. NOTE: there are **two** places in that file that you'll need to edit!
2. Use `make server` to run SEED on your machine.
3. Watch the logs to make sure SEED can connect to the database and run migrations.
4. After you see the following log message, go to `localhost:9000` and try logging in with `ops@opengb.com` `super-secret-password`.
```
web_1         | WSGI app 0 (mountpoint='') ready in 5 seconds on interpreter 0x7f0d8f63a030 pid: 145 (default app)
```
5. Browse SEED and make sure you can upload spreadsheets, view property data, etc.

#### What are the relevant tickets?
[FLEX-150](https://opengb.atlassian.net/browse/FLEX-150)

#### Screenshots (if appropriate)
N/A

[FLEX-150]: https://opengb.atlassian.net/browse/FLEX-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ