### PR TITLE
FLEX-263: :bug: Fix performance issue with importing energy meters from ESPM

### DIFF
--- a/seed/data_importer/meters_parser.py
+++ b/seed/data_importer/meters_parser.py
@@ -7,9 +7,10 @@ See also https://github.com/seed-platform/seed/main/LICENSE.md
 import logging
 import re
 from calendar import monthrange
+from collections import defaultdict
 from datetime import datetime, timedelta
 
-from django.db.models import Subquery
+from django.contrib.postgres.aggregates.general import ArrayAgg
 from django.utils.timezone import make_aware
 from pytz import timezone
 
@@ -20,7 +21,7 @@ from seed.data_importer.utils import (
 )
 from seed.lib.mcm import reader
 from seed.lib.superperms.orgs.models import Organization
-from seed.models import Meter, PropertyState, PropertyView
+from seed.models import Meter, Property, PropertyView
 
 _log = logging.getLogger(__name__)
 
@@ -183,19 +184,22 @@ class MetersParser(object):
 
         if self._cache_proposed_imports is None:
             self._cache_proposed_imports = []
+            # build cycle_names_by_property_id for the next part
+            all_property_ids = {property_id for property_ids in self._source_to_property_ids.values() for property_id in property_ids}
+            cycle_names_by_property_id = dict(
+                Property.objects.filter(id__in=all_property_ids)
+                .annotate(cycle_names=ArrayAgg("views__cycle__name"))
+                .values_list("id", "cycle_names")
+            )
+
             # Gather info based on property_id - cycles (query) and related pm_property_ids (parsed in different method)
             property_ids_info = {}
             for pm_property_id, property_ids in self._source_to_property_ids.items():
                 for property_id in property_ids:
-                    property_ids_info[property_id] = {'pm_id': pm_property_id}
-
-                    cycle_names = list(
-                        PropertyView.objects.select_related('cycle').
-                        order_by('cycle__end').
-                        filter(property_id=property_id).
-                        values_list('cycle__name', flat=True)
-                    )
-                    property_ids_info[property_id]['cycles'] = ', '.join(cycle_names)
+                    property_ids_info[property_id] = {
+                        "pm_id": pm_property_id,
+                        "cycles": ", ".join(cycle_names_by_property_id[property_id]),
+                    }
 
             # Put summaries together based on source type
             for meter in self.meter_and_reading_objs:
@@ -230,16 +234,14 @@ class MetersParser(object):
         start and end times are read. Also, PM meters have the possibility of
         having cost associated to individual raw details.
         """
+        # build out _source_to_property_ids, if we haven't yet
+        if len(self._source_to_property_ids) == 0:
+            self._build_out_source_to_property_ids_and_unlinkable_pm_ids()
+
         for raw_details in self._meters_and_readings_details:
-            meter_details = {
-                'source': self._source_type,
-            }
-
-            meter_details['source_id'] = str(raw_details['Portfolio Manager Meter ID'])
-
             # Continue/skip, if no property is found.
-            given_property_id = str(raw_details['Portfolio Manager ID'])
-            if not self._get_property_id(given_property_id, meter_details):
+            given_property_id = str(raw_details["Portfolio Manager ID"])
+            if given_property_id not in self._source_to_property_ids:
                 continue
 
             # Define start_time and end_time
@@ -264,6 +266,11 @@ class MetersParser(object):
             start_time = make_aware(unaware_start, timezone=self._tz)
             end_time = make_aware(unaware_end, timezone=self._tz)
 
+            meter_details = {
+                "source": self._source_type,
+                "source_id": str(raw_details["Portfolio Manager Meter ID"]),
+                "property_ids": self._source_to_property_ids.get(given_property_id),
+            }
             successful_parse = self._parse_meter_readings(raw_details, meter_details, start_time, end_time)
 
             # If Cost field is present and value is available, create Cost Meter and MeterReading
@@ -295,45 +302,21 @@ class MetersParser(object):
 
             self._parse_meter_readings(raw_details, meter_details, start_time, end_time)
 
-    def _get_property_id(self, source_id, shared_details):
+    def _build_out_source_to_property_ids_and_unlinkable_pm_ids(self):
+        """Populates self._source_to_property_ids
+
+        Its a dict. The keys are all the "Portfolio Manager ID"s in self._meters_and_readings_details,
+        the keys are a list of properties with that given pm_property_id.
         """
-        Using pm_property_id, find and cache property_ids to avoid querying for
-        the same property_id more than once. Return True when a property_id is
-        found.
+        pm_property_ids = {str(raw_details["Portfolio Manager ID"]) for raw_details in self._meters_and_readings_details}
+        relevant_views = PropertyView.objects.filter(property__organization_id=self._org_id, state__pm_property_id__in=pm_property_ids)
+        pm_property_id_and_property_id_pairs = relevant_views.values_list("state__pm_property_id", "property_id").distinct()
 
-        If no PropertyStates (and subsequent Properties) are found, flag the
-        PM ID as unlinkable, and False is returned.
-        """
-        # If the PM ID has been previously found to be unlinkable, return False
-        if source_id in self._unlinkable_pm_ids:
-            return False
+        self._source_to_property_ids = defaultdict(list)
+        for pm_property_id, property_id in pm_property_id_and_property_id_pairs:
+            self._source_to_property_ids[pm_property_id].append(property_id)
 
-        # Check cached property_ids
-        target_property_ids = self._source_to_property_ids.get(source_id, None)
-        if target_property_ids is not None:
-            shared_details['property_ids'] = target_property_ids
-            return True
-
-        # Start looking for possible matches - if some are found, capture all property_ids
-        possible_matches = PropertyState.objects.filter(
-            pm_property_id=source_id,
-            organization_id=self._org_id
-        )
-        if possible_matches.count() == 0:
-            self._unlinkable_pm_ids.add(source_id)
-            return False
-        else:
-            target_property_ids = list(
-                PropertyView.objects.
-                filter(state_id__in=Subquery(possible_matches.values('pk'))).
-                distinct('property_id').
-                values_list('property_id', flat=True)
-            )
-
-            shared_details['property_ids'] = target_property_ids
-            self._source_to_property_ids[source_id] = target_property_ids
-
-            return True
+        self._unlinkable_pm_ids = [str(pm_p_id) for pm_p_id in set(pm_property_ids) - set(self._source_to_property_ids.keys())]
 
     def _parse_meter_readings(self, raw_details, meter_details, start_time, end_time):
         """

--- a/seed/data_importer/tests/test_meters_parser.py
+++ b/seed/data_importer/tests/test_meters_parser.py
@@ -297,6 +297,7 @@ class MeterUtilTests(TestCase):
 
         meters_parser = MetersParser(self.org.id, raw_meters)
 
+        meters_parser.meter_and_reading_objs.sort(key=lambda x: (x["readings"][0]["reading"], x["property_id"]))
         self.assertEqual(meters_parser.meter_and_reading_objs, expected)
 
     def test_parse_meter_details_splits_monthly_info_including_cost_into_meter_data_and_readings(self):

--- a/seed/tests/test_meter_usage_import.py
+++ b/seed/tests/test_meter_usage_import.py
@@ -446,7 +446,7 @@ class MeterUsageImportTest(TestCase):
         new_cycle_factory = FakeCycleFactory(organization=new_org, user=self.user)
         new_cycle = new_cycle_factory.get_cycle(start=datetime(2010, 10, 10, tzinfo=get_current_timezone()))
 
-        new_property = self.property_factory.get_property()
+        new_property = self.property_factory.get_property(organization=new_org)
 
         PropertyView.objects.create(property=new_property, cycle=new_cycle, state=new_property_state)
 


### PR DESCRIPTION
#### Any background context you want to provide?
See https://github.com/SEED-platform/seed/pull/4867 for the upstream fix.

#### What's this PR do?
- :bug: Fixes a critical performance issue with importing meters from an Excel spreadsheet that was downloaded from ESPM. This was timing out for at least one of our bigger GRID clients, and with others growing to a similar size, we were in danger of being unable to upload any meter usage data to SEED.

#### How should this be manually tested?
1. Run the `opengb/seed:flex-263-meters-import-patch-test` Docker image locally, or check out this branch and build your own SEED Docker image.
2. Upload the properties and annual energy usage from the Excel spreadsheets attached to the FLEX-263 ticket.
3. Try uploading the meters from the same Excel spreadsheets.
4. You shouldn't run into any errors while importing the meters.

#### What are the relevant tickets?
See [FLEX-263](https://opengb.atlassian.net/browse/FLEX-263)

#### Screenshots (if appropriate)
N/A


[FLEX-263]: https://opengb.atlassian.net/browse/FLEX-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ