### PR TITLE
[NO-TICKET] :arrow_up: Update GitHub Actions runner image from Ubuntu 20.04 to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   # As a result, the DRYest method for now is to use a testing matrix and
   # use conditional steps for actually running the tests.
   unittests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         test_env: [django, functional, api]
@@ -101,7 +101,7 @@ jobs:
         if: ${{ always() }}
         run: docker logs seed_web
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         tox_env: [docs, precommit, mypy]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
#### Any background context you want to provide?
GitHub Actions no longer supports Ubuntu 20.04. The SEED automated tests and code quality checks depend on Ubuntu 20.04 to run. This means that none of these checks are able to run against open PRs, which brings significant risks to our forked version of SEED.

#### What's this PR do?
Updates the GitHub Actions runner from Ubuntu 20.04 to 22.04, allowing automated tests and code quality checks to run again.

#### How should this be manually tested?
N/A

#### What are the relevant tickets?
N/A

#### Screenshots (if appropriate)
N/A